### PR TITLE
Update main_settings.php

### DIFF
--- a/admin/main_settings.php
+++ b/admin/main_settings.php
@@ -95,7 +95,8 @@ class dynamictemplate_main_settings extends page_generic
 		}
 		
 		$this->tpl->assign_vars(array(
-			'KEY'			=> max($arrModuleIDs)+1,
+			//'KEY'			=> max($arrModuleIDs)+1,
+			'KEY'			=> (empty($arrModuleIDs) ? 1 : max($arrModuleIDs) + 1),
 			'LISTENER'		=> (new hdropdown('listener', array('options' => $this->user->lang('dynamictemplate_listener'), 'value' => '', 'name' => 'module[KEY][listener]')))->output(),
 			'EXPORT_DATA'	=> json_encode($arrExportData, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE),
 		));


### PR DESCRIPTION
Correct the below error by by changing line 98 to "'KEY' to 1 if $arrModuleIDs is empty, and if it's not empty, it will set 'KEY' to the maximum value in the array plus 1."

Message: Uncaught ValueError: max(): Argument #1 ($value) must contain at least one element in ...../plugins/dynamictemplate/admin/main_settings.php:98